### PR TITLE
Fix spelling of "Couldn't"

### DIFF
--- a/jsonassert/src/main/scala/com/stephenn/scalatest/jsonassert/JsonMatchers.scala
+++ b/jsonassert/src/main/scala/com/stephenn/scalatest/jsonassert/JsonMatchers.scala
@@ -20,7 +20,7 @@ trait JsonMatchers {
         case Failure(_) =>
           MatchResult(
             matches = false,
-            rawFailureMessage = "Couldnt parse json {0} did not equal {1}",
+            rawFailureMessage = "Could not parse json {0} did not equal {1}",
             rawNegatedFailureMessage = "Json should not have matched {0} {1}",
             args = Array(left.trim, right.trim)
           )

--- a/jsonassert/src/test/scala/com/stephenn/scalatest/jsonassert/JsonMatchersSpec.scala
+++ b/jsonassert/src/test/scala/com/stephenn/scalatest/jsonassert/JsonMatchersSpec.scala
@@ -59,7 +59,7 @@ class JsonMatchersSpec extends FunSpec with Matchers {
       val matchResult =
         JsonMatchers.matchJson("{}").apply("""{"a": [1  "two"]}""")
       matchResult.matches shouldBe false
-      matchResult.failureMessage shouldBe """Couldnt parse json "{"a": [1  "two"]}" did not equal "{}""""
+      matchResult.failureMessage shouldBe """Could not parse json "{"a": [1  "two"]}" did not equal "{}""""
     }
   }
 }


### PR DESCRIPTION
This change turns two instances of "Couldnt" into "Couldn't".